### PR TITLE
Greatly reduce the number of API calls

### DIFF
--- a/vaccheck.user.js
+++ b/vaccheck.user.js
@@ -17,41 +17,48 @@ var api = 'A0A47E806ED927C2F71C9B16EE27FD4D';
 var friends = $('.friendCheckbox').toArray();
 var recent = $('.friendCheckbox2').toArray();
 
-recent.forEach(function(friend) {
-    getPlayerBans(friend.outerHTML.match('friends\\[(.*?)\\]')[1], function(data) {
-        if(data.VACBanned && data.NumberOfGameBans > 0)
-            $('<span class="friendSmallText" style="display: block; color: rgb(255, 73, 73); font-weight: bold;">' + data.NumberOfVACBans + ' VAC ban(s); ' + data.NumberOfGameBans + ' game ban(s); ' + data.DaysSinceLastBan + ' day(s) ago</span>').insertAfter($('.friendSmallText', friend.closest('div')));
-        else if(data.NumberOfGameBans > 0)
-            $('<span class="friendSmallText" style="display: block; color: rgb(255, 73, 73); font-weight: bold;">' + data.NumberOfGameBans + ' game ban(s); ' + data.DaysSinceLastBan + ' day(s) ago</span>').insertAfter($('.friendSmallText', friend.closest('div')));
-        else if(data.VACBanned)
-            $('<span class="friendSmallText" style="display: block; color: rgb(255, 73, 73); font-weight: bold;">' + data.NumberOfVACBans + ' VAC ban(s); ' + data.DaysSinceLastBan + ' day(s) ago</span>').insertAfter($('.friendSmallText', friend.closest('div')));
-    });
-});
-
-friends.forEach(function(friend) {
-    var url = friend.closest('div').outerHTML.match('top.location.href=\'(.*?)\'')[1];
-    if(url.indexOf("/profiles/") === -1 && (url.indexOf("/id/") != -1)) {
-        resolveVanityURL(url.split("/id/")[1], function(id) {
-            getPlayerBans(id, function(data) {
-                if(data.VACBanned && data.NumberOfGameBans > 0)
-                    $('<span class="friendSmallText" style="display: block; color: rgb(255, 73, 73); font-weight: bold;">' + data.NumberOfVACBans + ' VAC ban(s); ' + data.NumberOfGameBans + ' game ban(s); ' + data.DaysSinceLastBan + ' day(s) ago</span>').insertAfter($('.friendSmallText', friend.closest('div')));
-                else if(data.NumberOfGameBans > 0)
-                    $('<span class="friendSmallText" style="display: block; color: rgb(255, 73, 73); font-weight: bold;">' + data.NumberOfGameBans + ' game ban(s); ' + data.DaysSinceLastBan + ' day(s) ago</span>').insertAfter($('.friendSmallText', friend.closest('div')));
-                else if(data.VACBanned)
-                    $('<span class="friendSmallText" style="display: block; color: rgb(255, 73, 73); font-weight: bold;">' + data.NumberOfVACBans + ' VAC ban(s); ' + data.DaysSinceLastBan + ' day(s) ago</span>').insertAfter($('.friendSmallText', friend.closest('div')));
-            });
-        });
+var querypairs = new Map();
+for (var i=0; i < recent.length; i++) {
+    var id = recent[i].outerHTML.match('friends\\[(.*?)\\]')[1];
+    if(!querypairs.has(id)) {
+        querypairs.set(id, [recent[i]]);
     } else {
-        getPlayerBans(url.split("/profiles/")[1], function(data) {
-            if(data.VACBanned && data.NumberOfGameBans > 0)
-                $('<span class="friendSmallText" style="display: block; color: rgb(255, 73, 73); font-weight: bold;">' + data.NumberOfVACBans + ' VAC ban(s); ' + data.NumberOfGameBans + ' game ban(s); ' + data.DaysSinceLastBan + ' day(s) ago</span>').insertAfter($('.friendSmallText', friend.closest('div')));
-            else if(data.NumberOfGameBans > 0)
-                $('<span class="friendSmallText" style="display: block; color: rgb(255, 73, 73); font-weight: bold;">' + data.NumberOfGameBans + ' game ban(s); ' + data.DaysSinceLastBan + ' day(s) ago</span>').insertAfter($('.friendSmallText', friend.closest('div')));
-            else if(data.VACBanned)
-                $('<span class="friendSmallText" style="display: block; color: rgb(255, 73, 73); font-weight: bold;">' + data.NumberOfVACBans + ' VAC ban(s); ' + data.DaysSinceLastBan + ' day(s) ago</span>').insertAfter($('.friendSmallText', friend.closest('div')));
-        });
+        querypairs.get(id).push(recent[i]);
     }
-});
+}
+getPlayerBans(querypairs);
+
+querypairs = new Map();
+vanitypairs = new Map();
+for (var i=0; i < friends.length; i++) {
+    var url = friends[i].closest('div').outerHTML.match('top.location.href=\'(.*?)\'')[1];
+    if(url.indexOf("/profiles/") === -1 && (url.indexOf("/id/") != -1)) {
+        var vanity = url.split("/id/")[1];
+        if(!vanitypairs.has(vanity)) {
+            vanitypairs.set(vanity, [friends[i]]);
+        } else {
+            vanitypairs.get(vanity).push(friends[i]);
+        }
+    } else {
+        var id = url.split("/profiles/")[1];
+        if(!querypairs.has(id)) {
+            querypairs.set(id, [friends[i]]);
+        } else {
+            querypairs.get(id).push(friends[i]);
+        }
+    }
+}
+getPlayerBans(querypairs);
+getVanityBans(vanitypairs);
+
+function writehtml(friend, data) {
+    if(data.VACBanned && data.NumberOfGameBans > 0)
+        $('<span class="friendSmallText" style="display: block; color: rgb(255, 73, 73); font-weight: bold;">' + data.NumberOfVACBans + ' VAC ban(s); ' + data.NumberOfGameBans + ' game ban(s); ' + data.DaysSinceLastBan + ' day(s) ago</span>').insertAfter($('.friendSmallText', friend.closest('div')));
+    else if(data.NumberOfGameBans > 0)
+        $('<span class="friendSmallText" style="display: block; color: rgb(255, 73, 73); font-weight: bold;">' + data.NumberOfGameBans + ' game ban(s); ' + data.DaysSinceLastBan + ' day(s) ago</span>').insertAfter($('.friendSmallText', friend.closest('div')));
+    else if(data.VACBanned)
+        $('<span class="friendSmallText" style="display: block; color: rgb(255, 73, 73); font-weight: bold;">' + data.NumberOfVACBans + ' VAC ban(s); ' + data.DaysSinceLastBan + ' day(s) ago</span>').insertAfter($('.friendSmallText', friend.closest('div')));
+}
 
 function resolveVanityURL(user, cb) {
     $.get('https://api.steampowered.com/ISteamUser/ResolveVanityURL/v0001/?key=' + api + '&vanityurl=' + user, function(data) {
@@ -59,8 +66,39 @@ function resolveVanityURL(user, cb) {
     });
 }
 
-function getPlayerBans(user, cb) {
+function getSingleBan(user, cb) {
     $.get('https://api.steampowered.com/ISteamUser/GetPlayerBans/v1/?key=' + api + '&steamids=' + user, function(data) {
-        return cb(data.players[0]);
+        return cb(data);
+    });
+}
+
+function getPlayerBans(querypairs) {
+    querylist = Array.from(querypairs.keys());
+    // the api will only query 100 players at a time
+    for (var start = 0; start < querylist.length; start += 90) {
+        idlist = querylist.slice(start, start + 90);
+        $.get('https://api.steampowered.com/ISteamUser/GetPlayerBans/v1/?key=' + api + '&steamids=' + idlist.join(), function(data) {
+            data["players"].forEach(function(bans) {
+                var friend = querypairs.get(bans.SteamId)
+                friend.forEach(function(ele) {
+                    return writehtml(ele, bans);
+                });
+            });
+        });
+    }
+}
+
+function getVanityBans(vanitypairs) {
+    var querylist = Array.from(vanitypairs.keys());
+
+    querylist.forEach(function(user) {
+        resolveVanityURL(user, function(id) {
+            getSingleBan(id, function(data) {
+                var friend = vanitypairs.get(user)
+                friend.forEach(function(ele) {
+                    writehtml(ele, data);
+                });
+            });
+        });
     });
 }

--- a/vaccheck.user.js
+++ b/vaccheck.user.js
@@ -68,7 +68,7 @@ function resolveVanityURL(user, cb) {
 
 function getSingleBan(user, cb) {
     $.get('https://api.steampowered.com/ISteamUser/GetPlayerBans/v1/?key=' + api + '&steamids=' + user, function(data) {
-        return cb(data);
+        return cb(data.players[0]);
     });
 }
 
@@ -93,10 +93,10 @@ function getVanityBans(vanitypairs) {
 
     querylist.forEach(function(user) {
         resolveVanityURL(user, function(id) {
-            getSingleBan(id, function(data) {
+            getSingleBan(id, function(bans) {
                 var friend = vanitypairs.get(user)
                 friend.forEach(function(ele) {
-                    writehtml(ele, data);
+                    writehtml(ele, bans);
                 });
             });
         });


### PR DESCRIPTION
Combine all directly know steam ids into the minimum number of api
calls. Also query vanity urls only one time.
